### PR TITLE
Application for the sataPi project

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,11 @@ Send a new PR to this repository on GitHub, append your application table. Radxa
 | Project Software: | |
 | Other Notes:      | pictures: https://twitter.com/arvidep/status/1445363759313297412 |
 
+
+| Project Name:     | sataPi                                                                                                                                                                                                                                                                                                       |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| CM3 Model:        | any model, but a eMMC one + more ram will help me in future in other projects                                                                                                                                                                                                                                |
+| Project Hardware: | PCB design still in progress                                                                                                                                                                                                                                                                                 |
+| Project Software: | Debian flavoured distros                                                                                                                                                                                                                                                                                     |
+| Other Notes:      | sataPi is a project that aims to fill the empty sata bay slots from a pc case with computing power. Since it is inside a pc, the power will be delivered trough standard conectors in pcs like molex or sata power. Project will be fully opensource, and maybe there will be a kickstarter campaign for it. |
+


### PR DESCRIPTION
sataPi is a carrier board for rpi CM4 or compatible boards that can be inserted into a 3.5" hdd bay in a pc case , and it will use a molex / sata power connector to be able to get its power. 


If you have any questions about , please feel free to ask