### PR TITLE
Application for OpenHD air unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,11 @@ Send a new PR to this repository on GitHub, append your application table. Radxa
 | Project Software: | |
 | Other Notes:      | pictures: https://twitter.com/arvidep/status/1445363759313297412 |
 
+
+| Project Name:     | OpenHD  air unit                      |
+| ----------------- | ----                                  |
+| CM3 Model:        | MIPI-CSI connection required          |
+| Project Hardware: |                                       |
+| Project Software: | https://github.com/OpenHD/Open.HD     |
+| Other Notes:      | https://www.patreon.com/OpenHD        |
+


### PR DESCRIPTION
Hello,

Our community is interested in your cm as a drop-in replacement for the rpi cm4 with various carrier boards.

I myself have a lot of experience with the rockchip platform (RV1126) and would love to contribute by adding sw support for the rpi cam (and more) on radxca cm3.

However, I cannot find any information on the compability of radxca cm3 and MIPI-CSI - does it route out the MIPI-CSI lanes equivalent to the CM4 such that a standart RPI cam can be connected to the RPI CM4 dev board ?
If so, there is a lot of potential for our specific use case.